### PR TITLE
feat: Enable IPv6 and configure custom IPAM for the `auteur-network` in `docker-compose.yml`.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -219,6 +219,14 @@ services:
 networks:
   auteur-network:
     driver: bridge
+    enable_ipv6: true
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.20.0.0/16
+          gateway: 172.20.0.1
+        - subnet: fd00:dead:beef::/48
+          gateway: fd00:dead:beef::1
 
 # ============================================
 # Volumes (Persistent Data)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced network infrastructure by enabling IPv6 support on auteur-network with full IP address management configuration. Implemented dual-stack IPv4/IPv6 subnets with dedicated gateways to improve network management capabilities and prepare deployment infrastructure for future IPv6 compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->